### PR TITLE
Add example specs for Controller and ToDoneService

### DIFF
--- a/backend/src/test/scala/todone/ControllerSuite.scala
+++ b/backend/src/test/scala/todone/ControllerSuite.scala
@@ -1,0 +1,40 @@
+package todone
+
+import munit.{FunSuite, ScalaCheckSuite}
+import org.scalacheck.Gen
+import org.scalacheck.Prop.{forAll, propBoolean}
+import todone.data.{Id, State, Task}
+
+class ControllerSuite extends FunSuite with ScalaCheckSuite {
+  test("Controller should get all the tasks") {
+    assertEquals(Controller.tasks.tasks.size, 2)
+  }
+  test("Controller should close the task when given a valid open task Id") {
+    val taskId = Id(1)
+    val before: Option[(Id, Task)] = Controller.tasks.tasks.find(_._1 == taskId)
+    val after: Option[Task] = Controller.close(taskId)
+    assertEquals(before.map(_._2.state), Some(State.open))
+    assertEquals(after.map(_.state), Some(State.closed))
+  }
+
+  // Here for simplicity we're relying on state from previous spec,
+  // In real life this could lead to issues with ordering, debugging, and mental load of keeping track of state.
+  // One way of addressing that is setting up and tearing down the "database" before every test or suite of
+  // tests by using fixtures https://scalameta.org/munit/docs/fixtures.html
+  test("Controller should do nothing when given a closed task Id") {
+    val taskId = Id(1)
+    val result: Option[Task] = Controller.close(taskId)
+    assertEquals(result.map(_.state), Some(State.closed))
+  }
+  test("Close method should return None when called with a nonexistent task Id") {
+    val taskId = Id(12345)
+    val result: Option[Task] = Controller.close(taskId)
+    assertEquals(result, Option.empty[Task])
+  }
+  // Same as the last test but using Scalacheck to try lots of different possible id inputs
+  property("Close method should return None when called with any nonexistent task Id") {
+    val taskIds: List[Int] = Controller.tasks.tasks.map(_._1.id)
+    val nonexistentTaskIdGenerator = Gen.choose(-10000,10000) suchThat(n => !taskIds.contains(n))
+    forAll(nonexistentTaskIdGenerator) {n => Controller.close(Id(n)).isEmpty}
+  }
+}

--- a/backend/src/test/scala/todone/ToDoneServiceSuite.scala
+++ b/backend/src/test/scala/todone/ToDoneServiceSuite.scala
@@ -1,0 +1,21 @@
+package todone
+
+import cats.effect.IO
+import munit.FunSuite
+import org.http4s.{Method, Request, Response, Status}
+import org.http4s.implicits._
+
+class ToDoneServiceSuite extends FunSuite {
+  test("ToDone service should return a 200 code when a GET request is made to '/api/tasks'") {
+    val request: Request[IO] = Request(method = Method.GET, uri = uri"/api/tasks")
+    val response: Response[IO] = ToDoneService.service.orNotFound.run(request).unsafeRunSync()
+    val expected: Status = Status.Ok
+    assertEquals(response.status, expected)
+  }
+  test("ToDone service should return a 404 code when a request is made to an undefined route") {
+    val request: Request[IO] = Request(method = Method.GET, uri = uri"/api/hi")
+    val response: Response[IO] = ToDoneService.service.orNotFound.run(request).unsafeRunSync()
+    val expected: Status = Status.NotFound
+    assertEquals(response.status, expected)
+  }
+}

--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,8 @@ val sharedSettings = Seq(
     "io.circe"      %%% "circe-core"    % circeVersion,
     "io.circe"      %%% "circe-generic" % circeVersion,
     "io.circe"      %%% "circe-parser"  % circeVersion,
-    "org.scalameta" %%% "munit"         % "0.7.17" % Test
+    "org.scalameta" %%% "munit"         % "0.7.17" % Test,
+    "org.scalameta" %% "munit-scalacheck" % "0.7.19" % Test
   ),
   scalacOptions ++= Seq(
     "-Ymacro-annotations",


### PR DESCRIPTION
- Add MUnit's scalacheck integration to dependences 
- A few MUnit specs for `Controller` and `ToDoneService`
- An example of ScalaCheck property use